### PR TITLE
Add basic support for default values in `isEnabled`

### DIFF
--- a/src/main/kotlin/io/getunleash/UnleashClient.kt
+++ b/src/main/kotlin/io/getunleash/UnleashClient.kt
@@ -82,9 +82,9 @@ class UnleashClient(
         val logger: Logger = LoggerFactory.getLogger(UnleashClient::class.java)
     }
 
-    override fun isEnabled(toggleName: String): Boolean {
+    override fun isEnabled(toggleName: String, defaultValue: Boolean): Boolean {
         val enabled = refreshPolicy.readToggleCache()[toggleName]?.enabled
-        return metricsReporter.log(toggleName,  enabled ?: false)
+        return metricsReporter.log(toggleName,  enabled ?: defaultValue)
     }
 
     override fun getVariant(toggleName: String): Variant {

--- a/src/main/kotlin/io/getunleash/UnleashClientSpec.kt
+++ b/src/main/kotlin/io/getunleash/UnleashClientSpec.kt
@@ -7,7 +7,7 @@ import java.io.Closeable
 import java9.util.concurrent.CompletableFuture
 
 interface UnleashClientSpec : Closeable {
-    fun isEnabled(toggleName: String): Boolean
+    fun isEnabled(toggleName: String, defaultValue: Boolean = false): Boolean
     fun getVariant(toggleName: String): Variant
     fun updateContext(context: UnleashContext): CompletableFuture<Void>
     fun getContext(): UnleashContext

--- a/src/test/kotlin/io/getunleash/UnleashClientTest.kt
+++ b/src/test/kotlin/io/getunleash/UnleashClientTest.kt
@@ -111,4 +111,22 @@ class UnleashClientTest {
             assertThat(updatedFuture).failsWithin(Duration.ofSeconds(2))
         }
     }
+
+    @Test
+    fun `Can check unknown toggle status with default value of false`() {
+        UnleashClient.newBuilder().unleashConfig(config).unleashContext(context).build().use { client ->
+            assertThat(client.isEnabled("unknownToggle")).isFalse
+            Thread.sleep(5000)
+            assertThat(client.isEnabled("unknownToggle")).isFalse
+        }
+    }
+
+    @Test
+    fun `Can check unknown toggle status with default value of true`() {
+        UnleashClient.newBuilder().unleashConfig(config).unleashContext(context).build().use { client ->
+            assertThat(client.isEnabled("unknownToggle", true)).isTrue
+            Thread.sleep(5000)
+            assertThat(client.isEnabled("unknownToggle", true)).isTrue
+        }
+    }
 }


### PR DESCRIPTION
In relation to: https://github.com/Unleash/unleash-android-proxy-sdk/issues/6#issue-978931420