### PR TITLE
fix: broadcast fetcher failed error (#15)

### DIFF
--- a/src/main/kotlin/io/getunleash/polling/AutoPollingPolicy.kt
+++ b/src/main/kotlin/io/getunleash/polling/AutoPollingPolicy.kt
@@ -62,7 +62,7 @@ class AutoPollingPolicy(
                 super.writeToggleCache(response.toggles)
                 this.broadcastTogglesUpdated()
             } else if (response.isFailed()) {
-
+                response?.error?.let(::broadcastTogglesErrored)
             }
         } catch (e: Exception) {
             this.broadcastTogglesErrored(e)


### PR DESCRIPTION
Autopolling didn't broadcast occuring failures to listeners. This change will delegate the exception if its available. 

Closes #15 .

I'm not sure if parsing the body of the text should also be considered, but for now it's not, since it doesn't contain an exception that can be passed on: https://github.com/Unleash/unleash-android-proxy-sdk/blob/547514fac8eb470776d78854d69a91629c25e1dd/src/main/kotlin/io/getunleash/polling/UnleashFetcher.kt#L89
