### PR TITLE
Add com.fasterxml to proguard

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,9 +15,10 @@ implementation("io.getunleash:unleash-android-proxy-sdk:${unleash.sdk.version}")
 - Currently aiming for a minimum SDK level of 21. Keeping in tune with OkHttp's requirement.
 
 ### Proguard
-For now, you'll need to have Proguard ignore our classes using
+For now, you'll need to have Proguard ignore our classes as well as fasterxml (Jackson)
 ```
 -keep public class io.getunleash.** {*;}
+-keep class com.fasterxml.** { *; }
 ```
 
 ### Now configure your client instance


### PR DESCRIPTION
#22 points out that when minifyIsEnabled there are some issues with Jackson serialization, so this PR adds fasterxml classes to proguard rules in the README so that customer's hopefully do not experience this.