### PR TITLE
Adds a way to postpone starting polling for features

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -3,7 +3,7 @@ import java.net.URL
 
 plugins {
     kotlin("jvm").version("1.6.20")
-    id("org.jetbrains.dokka").version("1.4.32")
+    id("org.jetbrains.dokka").version("1.7.10")
     `java-library`
     `maven-publish`
     signing
@@ -26,22 +26,22 @@ jacoco {
 dependencies {
     implementation(platform("org.jetbrains.kotlin:kotlin-bom"))
     implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8")
-    implementation("com.fasterxml.jackson.core:jackson-databind:2.13.2.2")
-    implementation("com.fasterxml.jackson.core:jackson-core:2.13.2")
-    implementation("com.fasterxml.jackson.module:jackson-module-kotlin:2.13.2")
-    implementation("com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.13.2")
+    implementation("com.fasterxml.jackson.core:jackson-databind:2.13.4")
+    implementation("com.fasterxml.jackson.core:jackson-core:2.13.4")
+    implementation("com.fasterxml.jackson.module:jackson-module-kotlin:2.13.4")
+    implementation("com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.13.4")
     api("net.sourceforge.streamsupport:android-retrofuture:1.7.4")
-    api("com.squareup.okhttp3:okhttp:4.9.3")
-    api("org.slf4j:slf4j-api:1.7.36")
+    api("com.squareup.okhttp3:okhttp:4.10.0")
+    api("org.slf4j:slf4j-api:2.0.3")
 
     testImplementation("org.jetbrains.kotlin:kotlin-test")
     testImplementation("org.jetbrains.kotlin:kotlin-test-junit5")
-    testImplementation("org.junit.jupiter:junit-jupiter-api:5.8.2")
-    testImplementation("org.junit.jupiter:junit-jupiter-engine:5.8.2")
-    testImplementation("org.assertj:assertj-core:3.22.0")
-    testImplementation("com.squareup.okhttp3:mockwebserver:4.9.3")
+    testImplementation("org.junit.jupiter:junit-jupiter-api:5.9.1")
+    testImplementation("org.junit.jupiter:junit-jupiter-engine:5.9.1")
+    testImplementation("org.assertj:assertj-core:3.23.1")
+    testImplementation("com.squareup.okhttp3:mockwebserver:4.10.0")
     testImplementation("org.mockito.kotlin:mockito-kotlin:4.0.0")
-    testImplementation("org.slf4j:slf4j-simple:1.7.36")
+    testImplementation("org.slf4j:slf4j-simple:2.0.3")
 }
 
 tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile> {

--- a/src/main/kotlin/io/getunleash/UnleashClient.kt
+++ b/src/main/kotlin/io/getunleash/UnleashClient.kt
@@ -105,6 +105,14 @@ class UnleashClient(
         this.refreshPolicy.close()
     }
 
+    override fun startPolling() {
+        this.refreshPolicy.startPolling()
+    }
+
+    override fun isPolling(): Boolean {
+        return this.refreshPolicy.isPolling()
+    }
+
     data class Builder(
         var httpClient: OkHttpClient? = null,
         var unleashConfig: UnleashConfig? = null,

--- a/src/main/kotlin/io/getunleash/UnleashClientSpec.kt
+++ b/src/main/kotlin/io/getunleash/UnleashClientSpec.kt
@@ -13,4 +13,7 @@ interface UnleashClientSpec : Closeable {
     fun getContext(): UnleashContext
     fun addTogglesUpdatedListener(listener: TogglesUpdatedListener)
     fun addTogglesErroredListener(listener: TogglesErroredListener)
+
+    fun startPolling()
+    fun isPolling(): Boolean
 }

--- a/src/main/kotlin/io/getunleash/polling/AutoPollingMode.kt
+++ b/src/main/kotlin/io/getunleash/polling/AutoPollingMode.kt
@@ -1,6 +1,6 @@
 package io.getunleash.polling
 
-class AutoPollingMode(val pollRateDuration: Long, val togglesUpdatedListener: TogglesUpdatedListener = TogglesUpdatedListener {  }, val erroredListener: TogglesErroredListener = TogglesErroredListener {  }) : PollingMode {
+class AutoPollingMode(val pollRateDuration: Long, val togglesUpdatedListener: TogglesUpdatedListener = TogglesUpdatedListener {  }, val erroredListener: TogglesErroredListener = TogglesErroredListener {  }, val pollImmediate: Boolean = true) : PollingMode {
     override fun pollingIdentifier(): String = "auto"
 
 }

--- a/src/main/kotlin/io/getunleash/polling/FilePollingPolicy.kt
+++ b/src/main/kotlin/io/getunleash/polling/FilePollingPolicy.kt
@@ -40,6 +40,15 @@ class FilePollingPolicy(
         val togglesInFile: ProxyResponse = Parser.jackson.readValue(filePollingConfig.fileToLoadFrom)
         super.writeToggleCache(togglesInFile.toggles.groupBy { it.name }.mapValues { (_, v) -> v.first() })
     }
+
+    override fun startPolling() {
+        // NOOP for FilePolling
+    }
+
+    override fun isPolling(): Boolean {
+        return false
+    }
+
     override fun getConfigurationAsync(): CompletableFuture<Map<String, Toggle>> {
         return CompletableFuture.completedFuture(super.readToggleCache())
     }

--- a/src/main/kotlin/io/getunleash/polling/PollingModes.kt
+++ b/src/main/kotlin/io/getunleash/polling/PollingModes.kt
@@ -29,6 +29,17 @@ object PollingModes {
     }
 
     /**
+     * Creates a configured auto polling config with a listener which receives updates when/if toggles get updated.
+     * However, this does not start polling until the user explicity calls [startPolling()]
+     * @param autoPollIntervalSeconds - Sets how often (in seconds) this policy should refresh the cache
+     * @param listener - What should the poller call when toggles are updated?
+     * @return the auto polling config
+     */
+    fun manuallyStartPolling(autoPollIntervalSeconds: Long, listener: TogglesUpdatedListener): PollingMode {
+        return AutoPollingMode(pollRateDuration = autoPollIntervalSeconds * 1000, togglesUpdatedListener = listener, pollImmediate = false)
+    }
+
+    /**
      * Creates a configured auto polling config with a listener which receives updates when/if toggles get updated
      * @param intervalInMs - Sets intervalInMs for how often this policy should refresh the cache
      * @param listener - What should the poller call when toggles are updated?
@@ -36,6 +47,17 @@ object PollingModes {
      */
     fun autoPollMs(intervalInMs: Long, listener: TogglesUpdatedListener): PollingMode {
         return AutoPollingMode(intervalInMs, listener)
+    }
+
+    /**
+     * Creates a configured auto polling config with a listener which receives updates when/if toggles get updated, but does not start polling automatically.
+     * For that you'll need to call startPolling() on the Policy
+     * @param intervalInMs - Sets intervalInMs for how often this policy should refresh the cache
+     * @param listener - What should the poller call when toggles are updated?
+     * @return the auto polling config
+     */
+    fun manuallyStartedPollMs(intervalInMs: Long, listener: TogglesUpdatedListener): PollingMode {
+        return AutoPollingMode(pollRateDuration = intervalInMs, togglesUpdatedListener = listener, pollImmediate = false)
     }
 
     fun fileMode(toggleFile: File): PollingMode {

--- a/src/main/kotlin/io/getunleash/polling/RefreshPolicy.kt
+++ b/src/main/kotlin/io/getunleash/polling/RefreshPolicy.kt
@@ -78,6 +78,18 @@ abstract class RefreshPolicy(
         }
     }
 
+    /**
+     * Subclasses should override this to implement their way of manually starting polling after context is updated.
+     * Typical usage would be to use [PollingModes.manuallyStartPolling] or [PollingModes.manuallyStartedPollMs] to create/configure your polling mode,
+     * and then call [startPolling()] on the Unleash client
+     */
+    abstract fun startPolling()
+
+    /**
+     * Subclasses should override this to signal to Unleash whether or not they're actively polling
+     */
+    abstract fun isPolling(): Boolean
+
     fun getLatestCachedValue(): Map<String, Toggle> = this.inMemoryConfig
 
     override fun close() {


### PR DESCRIPTION
fixes: #29

[jagtejsodhi](https://github.com/jagtejsodhi) requested that there was a way to control when polling started.

This PR adds that.