### PR TITLE
fix: Adhere to same spec as proxy-client-js

### DIFF
--- a/src/main/kotlin/io/getunleash/UnleashClient.kt
+++ b/src/main/kotlin/io/getunleash/UnleashClient.kt
@@ -94,6 +94,7 @@ class UnleashClient(
 
     override fun updateContext(context: UnleashContext): CompletableFuture<Void> {
         refreshPolicy.context = context
+        this.unleashContext = context
         return refreshPolicy.refreshAsync()
     }
 

--- a/src/main/kotlin/io/getunleash/polling/UnleashFetcher.kt
+++ b/src/main/kotlin/io/getunleash/polling/UnleashFetcher.kt
@@ -110,12 +110,12 @@ open class UnleashFetcher(
 
     private fun buildContextUrl(ctx: UnleashContext): HttpUrl {
         var contextUrl = proxyUrl.newBuilder().addQueryParameter("appName", ctx.appName)
-            .addQueryParameter("env", ctx.environment)
+            .addQueryParameter("environment", ctx.environment)
             .addQueryParameter("userId", ctx.userId)
             .addQueryParameter("remoteAddress", ctx.remoteAddress)
             .addQueryParameter("sessionId", ctx.sessionId)
         ctx.properties.entries.forEach {
-            contextUrl = contextUrl.addQueryParameter(it.key, it.value)
+            contextUrl = contextUrl.addQueryParameter("properties[${it.key}]", it.value)
         }
         return contextUrl.build()
     }


### PR DESCRIPTION
Previously this library added all properties on toplevel as separate GET parameters. The proxy server expects properties to be nested under the properties key, so this fix makes sure that properties are added as properties[key] = value rather than key=value

Also, updates client's context when calling update context, so that further updates takes original updates under consideration. Saves our users a manual call to update client context.

fixes: #14
fixes: #13

