### PR TITLE
Make sure alpha and beta releases are flagged as prereleases

### DIFF
--- a/.github/workflows/deployrelease.yml
+++ b/.github/workflows/deployrelease.yml
@@ -29,3 +29,4 @@ jobs:
         with:
           tag_name: ${{ github.ref }}
           release_name: ${{ github.ref }}
+          prerelease: ${{ contains(github.ref, 'beta') || contains(github.ref, 'alpha') }}


### PR DESCRIPTION
We've done this for most of the other repos where we do automated release creations. This PR flags alpha and beta as prereleases.