### PR TITLE
docs: make KDoc link a normal link

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 [![Coverage Status](https://coveralls.io/repos/github/Unleash/unleash-android-proxy-sdk/badge.svg?branch=main)](https://coveralls.io/github/Unleash/unleash-android-proxy-sdk?branch=main)
 [![main](https://github.com/Unleash/unleash-android-proxy-sdk/actions/workflows/test.yml/badge.svg)](https://github.com/Unleash/unleash-android-proxy-sdk/actions/workflows/test.yml)
 [![latest](https://badgen.net/maven/v/maven-central/io.getunleash/unleash-android-proxy-sdk)](https://search.maven.org/search?q=g:io.getunleash%20AND%20a:unleash-android-proxy-sdk)
-[![KDoc](https://docs.getunleash.io/unleash-android-proxy-sdk)
+[KDoc](https://docs.getunleash.io/unleash-android-proxy-sdk)
 
 ## Getting started
 


### PR DESCRIPTION
The KDoc link looks like a malformed shield/badge, but I can't figure out what kind of badge it should have, so I made it into a normal link instead.

If it should be a badge, then where do I find the badge source?