### PR TITLE
Fix/add authorization header for metrics reporting

### DIFF
--- a/samples/android/app/build.gradle
+++ b/samples/android/app/build.gradle
@@ -36,6 +36,7 @@ android {
     buildFeatures {
         viewBinding true
     }
+    namespace 'com.example.unleash'
 }
 
 dependencies {

--- a/samples/android/app/build.gradle
+++ b/samples/android/app/build.gradle
@@ -51,7 +51,7 @@ dependencies {
     implementation 'androidx.constraintlayout:constraintlayout:2.1.0'
     implementation 'androidx.navigation:navigation-fragment-ktx:2.3.5'
     implementation 'androidx.navigation:navigation-ui-ktx:2.3.5'
-    implementation 'io.getunleash:unleash-android-proxy-sdk:0.3.1'
+    implementation 'io.getunleash:unleash-android-proxy-sdk:0.5.0'
     testImplementation 'junit:junit:4.13.2'
     androidTestImplementation 'androidx.test.ext:junit:1.1.3'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.4.0'

--- a/samples/android/app/src/main/AndroidManifest.xml
+++ b/samples/android/app/src/main/AndroidManifest.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.example.unleash">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
     <uses-permission android:name="android.permission.INTERNET" />
     <application
         android:name=".UnleashApplication"

--- a/samples/android/app/src/main/java/com/example/unleash/UnleashApplication.kt
+++ b/samples/android/app/src/main/java/com/example/unleash/UnleashApplication.kt
@@ -35,8 +35,8 @@ internal object UnleashClientModule {
                     .appName("unleash-android")
                     .instanceId("unleash-android-${Random.nextLong()}")
                     .enableMetrics()
-                    .clientSecret("*:development.8e2b03838a586e7de5009e08b56e839cf538f6f9968dc03eddcb44d7")
-                    .proxyUrl("http:///192.168.50.135:3063/api/frontend")
+                    .clientKey("get a frontend key from instance you connect to")
+                    .proxyUrl("http:///UNLEASHURL:4242/api/frontend")
                     .pollingMode(
                         PollingModes.autoPoll(
                             autoPollIntervalSeconds = 15
@@ -44,6 +44,7 @@ internal object UnleashClientModule {
 
                         }
                     )
+                    .metricsInterval(5000)
                     .build()
             )
             .cache(InMemoryToggleCache())

--- a/samples/android/app/src/main/java/com/example/unleash/UnleashApplication.kt
+++ b/samples/android/app/src/main/java/com/example/unleash/UnleashApplication.kt
@@ -34,9 +34,9 @@ internal object UnleashClientModule {
                 UnleashConfig.newBuilder()
                     .appName("unleash-android")
                     .instanceId("unleash-android-${Random.nextLong()}")
-                    .environment("dev")
-                    .clientSecret("s1")
-                    .proxyUrl("http://192.168.1.42:3200/proxy")
+                    .enableMetrics()
+                    .clientSecret("*:development.8e2b03838a586e7de5009e08b56e839cf538f6f9968dc03eddcb44d7")
+                    .proxyUrl("http:///192.168.50.135:3063/api/frontend")
                     .pollingMode(
                         PollingModes.autoPoll(
                             autoPollIntervalSeconds = 15
@@ -44,7 +44,7 @@ internal object UnleashClientModule {
 
                         }
                     )
-                    .environment("dev").build()
+                    .build()
             )
             .cache(InMemoryToggleCache())
             .unleashContext(unleashContext)

--- a/samples/android/build.gradle
+++ b/samples/android/build.gradle
@@ -1,13 +1,13 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 buildscript {
-    ext.kotlin_version = "1.5.30"
-    ext.hilt_version = "2.38.1"
+    ext.kotlin_version = '1.6.21'
+    ext.hilt_version = '2.40.1'
     repositories {
         google()
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:7.0.2'
+        classpath 'com.android.tools.build:gradle:8.0.2'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         classpath "com.google.dagger:hilt-android-gradle-plugin:$hilt_version"
 

--- a/samples/android/gradle.properties
+++ b/samples/android/gradle.properties
@@ -17,3 +17,6 @@ org.gradle.jvmargs=-Xmx2048m -Dfile.encoding=UTF-8
 android.useAndroidX=true
 # Kotlin code style for this project: "official" or "obsolete":
 kotlin.code.style=official
+android.defaults.buildfeatures.buildconfig=true
+android.nonTransitiveRClass=false
+android.nonFinalResIds=false

--- a/samples/android/gradle/wrapper/gradle-wrapper.properties
+++ b/samples/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Tue May 25 09:19:20 CEST 2021
 distributionBase=GRADLE_USER_HOME
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.0-bin.zip
 distributionPath=wrapper/dists
 zipStorePath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME

--- a/src/main/kotlin/io/getunleash/metrics/MetricsReporter.kt
+++ b/src/main/kotlin/io/getunleash/metrics/MetricsReporter.kt
@@ -82,7 +82,7 @@ class HttpMetricsReporter(val config: UnleashConfig, val started: Date = Date())
             environment = config.environment ?: "not-set",
             bucket = bucket.copy(stop = Date())
         )
-        val request = Request.Builder().url(metricsUrl).post(
+        val request = Request.Builder().header("Authorization", config.clientKey).url(metricsUrl).post(
             Parser.jackson.writeValueAsString(report).toRequestBody("application/json".toMediaType())
         ).build()
         client.newCall(request).enqueue(object : Callback {

--- a/src/test/kotlin/io/getunleash/polling/TestResponses.kt
+++ b/src/test/kotlin/io/getunleash/polling/TestResponses.kt
@@ -18,7 +18,8 @@ object TestResponses {
                                 "type": "string",
                                 "value": "some-text"
                             }
-                        }
+                        },
+                        "impressionData": true
                     }, {
                         "name": "featureToggle",
                         "enabled": true,


### PR DESCRIPTION
### What
We haven't been able to report metrics from this SDK because we had forgotten to add an authorization header. This PR adds the clientKey used to fetch toggles as the authorization header for reporting metrics as well.

### Discussion/Nice to be aware
In addition this PR updates the sample application to use most recent Android Development tools. This makes us able to launch the demo in Android Studio Flamingo