### PR TITLE
fix: rollback to Kotlin 1.6 to not break compatitbility

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -2,7 +2,7 @@ import org.jetbrains.dokka.gradle.DokkaTask
 import java.net.URL
 
 plugins {
-    kotlin("jvm").version("1.8.21")
+    kotlin("jvm").version("1.6.21")
     id("org.jetbrains.dokka").version("1.7.10")
     `java-library`
     `maven-publish`


### PR DESCRIPTION
0.5.1 Suddenly required Kotlin 1.8. We should release 0.5.2 still using Kotlin 1.6, and then release a 0.6 series with upgrading to 1.8.x