### PR TITLE
fix: count "yes" and "no" as part of getVariant

### DIFF
--- a/src/main/kotlin/io/getunleash/UnleashClient.kt
+++ b/src/main/kotlin/io/getunleash/UnleashClient.kt
@@ -88,7 +88,10 @@ class UnleashClient(
     }
 
     override fun getVariant(toggleName: String): Variant {
-        val variant = refreshPolicy.readToggleCache()[toggleName]?.variant ?: disabledVariant
+        val variant =
+                if (isEnabled(toggleName))
+                        refreshPolicy.readToggleCache()[toggleName]?.variant ?: disabledVariant
+                else disabledVariant
         return metricsReporter.logVariant(toggleName, variant)
     }
 

--- a/src/main/kotlin/io/getunleash/UnleashClient.kt
+++ b/src/main/kotlin/io/getunleash/UnleashClient.kt
@@ -89,9 +89,11 @@ class UnleashClient(
 
     override fun getVariant(toggleName: String): Variant {
         val variant =
-                if (isEnabled(toggleName))
-                        refreshPolicy.readToggleCache()[toggleName]?.variant ?: disabledVariant
-                else disabledVariant
+                if (isEnabled(toggleName)) {
+                    refreshPolicy.readToggleCache()[toggleName]?.variant ?: disabledVariant
+                } else {
+                    disabledVariant
+                }
         return metricsReporter.logVariant(toggleName, variant)
     }
 

--- a/src/test/kotlin/io/getunleash/metrics/MetricsTest.kt
+++ b/src/test/kotlin/io/getunleash/metrics/MetricsTest.kt
@@ -147,7 +147,7 @@ class MetricsTest {
             "unleash-android-proxy-sdk" to EvaluationCount(0, 100),
             "non-existing-toggle" to EvaluationCount(0, 100),
             "Test_release" to EvaluationCount(100, 0),
-            "demoApp.step4" to EvaluationCount(0, 0, mutableMapOf("red" to 100))
+            "demoApp.step4" to EvaluationCount(100, 0, mutableMapOf("red" to 100))
         ))
         server.enqueue(MockResponse())
         // No activity since last report, bucket should be empty

--- a/src/test/kotlin/io/getunleash/metrics/MetricsTest.kt
+++ b/src/test/kotlin/io/getunleash/metrics/MetricsTest.kt
@@ -103,6 +103,28 @@ class MetricsTest {
         assertThat(toggles).containsEntry("unleash_android_sdk_demo", EvaluationCount(100, 0))
     }
 
+
+    @Test
+    fun `getVariant calls also records "yes" and "no"`() {
+        val reporter = TestReporter()
+        val client = UnleashClient(config, context, metricsReporter = reporter)
+        repeat(100) {
+			// toggle doesn't exist
+			client.getVariant("some-non-existing-toggle")
+			// toggle with variants
+			client.getVariant("asdasd")
+			// toggle without variants
+			client.getVariant("cache.buster")
+        }
+        val toggles = reporter.getToggles()
+
+        assertThat(toggles).containsAllEntriesOf(mutableMapOf(
+            "some-non-existing-toggle" to EvaluationCount(0, 100, mutableMapOf("disabled" to 100)),
+            "asdasd" to EvaluationCount(100, 0, mutableMapOf("123" to 100)),
+            "cache.buster" to EvaluationCount(0, 100, mutableMapOf("disabled" to 100)),
+        ))
+    }
+
     @Test
     fun `reporting resets period`() {
         val reporter = TestReporter()

--- a/src/test/kotlin/io/getunleash/metrics/MetricsTest.kt
+++ b/src/test/kotlin/io/getunleash/metrics/MetricsTest.kt
@@ -121,7 +121,7 @@ class MetricsTest {
         assertThat(toggles).containsAllEntriesOf(mutableMapOf(
             "some-non-existing-toggle" to EvaluationCount(0, 100, mutableMapOf("disabled" to 100)),
             "asdasd" to EvaluationCount(100, 0, mutableMapOf("123" to 100)),
-            "cache.buster" to EvaluationCount(0, 100, mutableMapOf("disabled" to 100)),
+            "cache.buster" to EvaluationCount(100, 0, mutableMapOf("disabled" to 100)),
         ))
     }
 


### PR DESCRIPTION
This PR fixes a behavior issue related to counting metrics: when counting variant metrics, we should also count "yes" and "no" / enabled and disabled.

This PR changes one of the existing tests to align with this behavior and adds an extra test to specifically about this.