### PR TITLE
feat: TogglesCheckedListener and ReadyListener

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ build
 *.iml
 *.ipr
 *.iws
+bin/

--- a/README.md
+++ b/README.md
@@ -126,7 +126,8 @@ val unleashClient = UnleashClient(config = unleashConfig, context = myAppContext
 #### PollingModes
 ##### Autopolling
 If you'd like for changes in toggles to take effect for you; use AutoPolling.
-You can configure the pollInterval and a listener that gets notified when toggles are updated in the background thread
+You can configure the pollInterval and a listener that gets notified when toggles are updated in the background thread. 
+If you set the poll interval to 0, the SDK will fetch once, but not set up polling.
 
 The listener is a no-argument lambda that gets called by the RefreshPolicy for every poll that
 1. Does not return `304 - Not Modified`

--- a/src/main/kotlin/io/getunleash/polling/AutoPollingMode.kt
+++ b/src/main/kotlin/io/getunleash/polling/AutoPollingMode.kt
@@ -1,6 +1,19 @@
 package io.getunleash.polling
 
-class AutoPollingMode(val pollRateDuration: Long, val togglesUpdatedListener: TogglesUpdatedListener = TogglesUpdatedListener {  }, val erroredListener: TogglesErroredListener = TogglesErroredListener {  }, val pollImmediate: Boolean = true) : PollingMode {
+/**
+ * @param pollRateDuration - How long (in seconds) between each poll
+ * @param togglesUpdatedListener - A listener that will be notified each time a poll actually updates the evaluation result
+ * @param erroredListener - A listener that will be notified each time a poll fails. The notification will include the Exception
+ * @param togglesCheckedListener - A listener that will be notified each time a poll completed. Will be called regardless of the check succeeded or failed.
+ * @param readyListener - A listener that will be notified after the poller is done instantiating, i.e. has an evaluation result in its cache. Each ready listener will receive only one notification
+ * @param pollImmediate - Set to true, the poller will immediately poll for configuration and then call the ready listener. Set to false, you will need to call [startPolling()) to actually talk to proxy/Edge
+ */
+class AutoPollingMode(val pollRateDuration: Long,
+                      val togglesUpdatedListener: TogglesUpdatedListener? = null,
+                      val erroredListener: TogglesErroredListener? = null,
+                      val togglesCheckedListener: TogglesCheckedListener? = null,
+                      val readyListener: ReadyListener? = null,
+                      val pollImmediate: Boolean = true) : PollingMode {
     override fun pollingIdentifier(): String = "auto"
 
 }

--- a/src/main/kotlin/io/getunleash/polling/AutoPollingPolicy.kt
+++ b/src/main/kotlin/io/getunleash/polling/AutoPollingPolicy.kt
@@ -117,6 +117,7 @@ class AutoPollingPolicy(
         this.listeners.clear()
         this.errorListeners.clear()
         this.checkListeners.clear()
+        this.readyListeners.clear()
         this.timer = null
     }
 }

--- a/src/main/kotlin/io/getunleash/polling/AutoPollingPolicy.kt
+++ b/src/main/kotlin/io/getunleash/polling/AutoPollingPolicy.kt
@@ -28,24 +28,37 @@ class AutoPollingPolicy(
     private val initFuture = CompletableFuture<Unit>()
     private var timer: Timer? = null
     init {
-        autoPollingConfig.togglesUpdatedListener.let { listeners.add(it) }
-        autoPollingConfig.erroredListener.let { errorListeners.add(it) }
+        autoPollingConfig.togglesUpdatedListener?.let { listeners.add(it) }
+        autoPollingConfig.togglesCheckedListener?.let { checkListeners.add(it) }
+        autoPollingConfig.erroredListener?.let { errorListeners.add(it) }
+        autoPollingConfig.readyListener?.let { readyListeners.add(it) }
         if (autoPollingConfig.pollImmediate) {
-            timer =
-                timer(
-                    name = "unleash_toggles_fetcher",
-                    initialDelay = 0L,
-                    daemon = true,
-                    period = autoPollingConfig.pollRateDuration
-                ) {
-                    updateToggles()
-                    if (!initialized.getAndSet(true)) {
-                        initFuture.complete(null)
-                    }
+            if (autoPollingConfig.pollRateDuration > 0) {
+                timer =
+                        timer(
+                                name = "unleash_toggles_fetcher",
+                                initialDelay = 0L,
+                                daemon = true,
+                                period = autoPollingConfig.pollRateDuration
+                        ) {
+                            updateToggles()
+                            if (!initialized.getAndSet(true)) {
+                                super.broadcastReady()
+                                initFuture.complete(null)
+                            }
+                        }
+            } else {
+                updateToggles()
+                if (!initialized.getAndSet(true)) {
+                    super.broadcastReady()
+                    initFuture.complete(null)
                 }
+            }
         }
     }
 
+    override val isReady: AtomicBoolean
+        get() = initialized
 
     override fun getConfigurationAsync(): CompletableFuture<Map<String, Toggle>> {
         return if (this.initFuture.isDone) {
@@ -56,13 +69,20 @@ class AutoPollingPolicy(
     }
 
     override fun startPolling() {
-        this.timer?.cancel()
-        this.timer =  timer(
-            name = "unleash_toggles_fetcher",
-            initialDelay = 0L,
-            daemon = true,
-            period = autoPollingConfig.pollRateDuration
-        ) {
+        if (autoPollingConfig.pollRateDuration > 0) {
+            this.timer?.cancel()
+            this.timer = timer(
+                    name = "unleash_toggles_fetcher",
+                    initialDelay = 0L,
+                    daemon = true,
+                    period = autoPollingConfig.pollRateDuration
+            ) {
+                updateToggles()
+                if (!initialized.getAndSet(true)) {
+                    initFuture.complete(null)
+                }
+            }
+        } else {
             updateToggles()
             if (!initialized.getAndSet(true)) {
                 initFuture.complete(null)
@@ -79,37 +99,24 @@ class AutoPollingPolicy(
             val response = super.fetcher().getTogglesAsync(context).get()
             val cached = super.readToggleCache()
             if (response.isFetched() && cached != response.toggles) {
-                super.writeToggleCache(response.toggles)
-                this.broadcastTogglesUpdated()
+                logger.trace("Content was not equal")
+                super.writeToggleCache(response.toggles) // This will also broadcast updates
             } else if (response.isFailed()) {
-                response?.error?.let(::broadcastTogglesErrored)
+                response?.error?.let { e -> super.broadcastTogglesErrored(e) }
             }
         } catch (e: Exception) {
-            this.broadcastTogglesErrored(e)
+            super.broadcastTogglesErrored(e)
             logger.warn("Exception in AutoPollingCachePolicy", e)
         }
+        logger.info("Done checking. Broadcasting check result")
+        super.broadcastTogglesChecked()
     }
-
-    private fun broadcastTogglesErrored(e: Exception) {
-        synchronized(errorListeners) {
-            errorListeners.forEach {
-                it.onError(e)
-            }
-        }
-    }
-
-    private fun broadcastTogglesUpdated() {
-        synchronized(listeners) {
-            listeners.forEach {
-                it.onTogglesUpdated()
-            }
-        }
-    }
-
     override fun close() {
         super.close()
         this.timer?.cancel()
         this.listeners.clear()
+        this.errorListeners.clear()
+        this.checkListeners.clear()
         this.timer = null
     }
 }

--- a/src/main/kotlin/io/getunleash/polling/FilePollingMode.kt
+++ b/src/main/kotlin/io/getunleash/polling/FilePollingMode.kt
@@ -6,8 +6,9 @@ import java.io.File
 /**
  * Configuration for FilePollingPolicy. Sets up where the policy loads the toggles from
  * @param fileToLoadFrom
+ * @param readyListener - Will broadcast a ready event (Once the File is loaded and the toggle cache is populated)
  * @since 0.2
  */
-class FilePollingMode(val fileToLoadFrom: File) : PollingMode {
+class FilePollingMode(val fileToLoadFrom: File, val readyListener: ReadyListener? = null) : PollingMode {
     override fun pollingIdentifier(): String = "file"
 }

--- a/src/main/kotlin/io/getunleash/polling/PollingModes.kt
+++ b/src/main/kotlin/io/getunleash/polling/PollingModes.kt
@@ -40,6 +40,15 @@ object PollingModes {
     }
 
     /**
+     * Creates a configured poller that fetches once at initialisation and then never polls
+     * @param listener - What should the poller call when toggles are updated?
+     * @param readyListener - What should the poller call when it has initialised its toggles cache
+     */
+    fun fetchOnce(listener: TogglesUpdatedListener? = null, readyListener: ReadyListener? = null): PollingMode {
+        return AutoPollingMode(pollRateDuration = 0, togglesUpdatedListener = listener, readyListener = readyListener)
+    }
+
+    /**
      * Creates a configured auto polling config with a listener which receives updates when/if toggles get updated
      * @param intervalInMs - Sets intervalInMs for how often this policy should refresh the cache
      * @param listener - What should the poller call when toggles are updated?
@@ -60,8 +69,8 @@ object PollingModes {
         return AutoPollingMode(pollRateDuration = intervalInMs, togglesUpdatedListener = listener, pollImmediate = false)
     }
 
-    fun fileMode(toggleFile: File): PollingMode {
-        return FilePollingMode(toggleFile)
+    fun fileMode(toggleFile: File, readyListener: ReadyListener? = null): PollingMode {
+        return FilePollingMode(toggleFile, readyListener)
     }
 
 

--- a/src/main/kotlin/io/getunleash/polling/ReadyListener.kt
+++ b/src/main/kotlin/io/getunleash/polling/ReadyListener.kt
@@ -1,0 +1,5 @@
+package io.getunleash.polling
+
+fun interface ReadyListener {
+    fun onReady(): Unit
+}

--- a/src/main/kotlin/io/getunleash/polling/TogglesCheckedListener.kt
+++ b/src/main/kotlin/io/getunleash/polling/TogglesCheckedListener.kt
@@ -1,0 +1,5 @@
+package io.getunleash.polling
+
+fun interface TogglesCheckedListener {
+    fun onTogglesChecked(): Unit
+}

--- a/src/test/kotlin/io/getunleash/metrics/MetricsTest.kt
+++ b/src/test/kotlin/io/getunleash/metrics/MetricsTest.kt
@@ -105,7 +105,7 @@ class MetricsTest {
 
 
     @Test
-    fun `getVariant calls also records "yes" and "no"`() {
+    fun `getVariant calls also records yes and no`() {
         val reporter = TestReporter()
         val client = UnleashClient(config, context, metricsReporter = reporter)
         repeat(100) {

--- a/src/test/kotlin/io/getunleash/polling/FilePollingPolicyTest.kt
+++ b/src/test/kotlin/io/getunleash/polling/FilePollingPolicyTest.kt
@@ -7,6 +7,7 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.mockito.kotlin.mock
 import java.io.File
+import java.util.concurrent.atomic.AtomicBoolean
 
 class FilePollingPolicyTest {
 
@@ -25,6 +26,26 @@ class FilePollingPolicyTest {
         val toggles = filePollingPolicy.getConfigurationAsync().get()
         assertThat(toggles).isNotEmpty()
         assertThat(toggles).containsKey("unleash_android_sdk_demo")
+    }
+
+    @Test
+    fun `broadcasts the ready event once it has read from file`() {
+
+        val uri = FilePollingPolicy::class.java.classLoader.getResource("proxyresponse.json")!!.toURI()
+        val file = File(uri)
+        val ready = AtomicBoolean(false)
+        val pollingMode = PollingModes.fileMode(file) { ready.set(true) }
+        val filePollingPolicy = FilePollingPolicy(
+                unleashFetcher = mock(),
+                cache = InMemoryToggleCache(),
+                config = UnleashConfig("doesn't matter", clientKey = ""),
+                context = UnleashContext(),
+                filePollingConfig = pollingMode as FilePollingMode
+        )
+        val toggles = filePollingPolicy.getConfigurationAsync().get()
+        assertThat(toggles).isNotEmpty()
+        assertThat(toggles).containsKey("unleash_android_sdk_demo")
+        assertThat(ready.get()).isTrue
     }
 
     @Test


### PR DESCRIPTION
### What
Adds support for two new Listener interfaces.
TogglesCheckedListener which will be notified upon each poll
ReadyListener which will be notified as the RefreshPolicy completes it's initialisation

In addition: Adds support for setting pollRateDuration to 0 for the AutoPollingMode/AutoPollingPolicy to not poll at all. This will make the RefreshPolicy do one query to the server and then turn passive.

fixes: #47, #49