### PR TITLE
chore(ci): Updated actions

### DIFF
--- a/.github/workflows/deployrelease.yml
+++ b/.github/workflows/deployrelease.yml
@@ -7,10 +7,10 @@ on:
 
 jobs:
   deploy-release:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     if: startsWith(github.ref, 'refs/tags')
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         name: Checkout code
       - uses: burrunan/gradle-cache-action@v1
         name: Deploy Release

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -10,17 +10,18 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
-      - uses: actions/setup-java@v1
+      - uses: actions/setup-java@v2
         with:
           java-version: 11
+          distribution: zulu
 
       - name: Build docs
         run: ./gradlew --no-daemon dokkaHtml
 
       - name: Deploy 🚀
-        uses: JamesIves/github-pages-deploy-action@4.1.3
+        uses: JamesIves/github-pages-deploy-action@v4
         with:
           branch: gh-pages # The branch the action should deploy to.
           folder: build/dokka/html # The folder the action should deploy.

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,14 +8,15 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         name: Checkout code
       - name: Setup JDK
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v2
         with:
           java-version: 17
+          distribution: zulu
       - uses: burrunan/gradle-cache-action@v1
         name: Build and test
         env:


### PR DESCRIPTION
We have deprecation warning on quite a few of our actions. This PR bumps us up to latest of checkout and migrates to ubuntu-22.04