### PR TITLE
Provide custom OkHttpClient for MetricsReporter

### DIFF
--- a/src/main/kotlin/io/getunleash/UnleashClient.kt
+++ b/src/main/kotlin/io/getunleash/UnleashClient.kt
@@ -40,7 +40,7 @@ class UnleashClient(
             )
         ).build(),
     val cache: ToggleCache = InMemoryToggleCache(),
-    val metricsReporter: MetricsReporter = unleashConfig.reportMetrics?.let { HttpMetricsReporter(unleashConfig) } ?: NonReporter()
+    val metricsReporter: MetricsReporter = unleashConfig.reportMetrics?.let { HttpMetricsReporter(unleashConfig, it.httpClient) } ?: NonReporter()
 ) : UnleashClientSpec {
     private val fetcher: UnleashFetcher = UnleashFetcher(unleashConfig = unleashConfig, httpClient = httpClient)
     private val refreshPolicy: RefreshPolicy = when (unleashConfig.pollingMode) {

--- a/src/main/kotlin/io/getunleash/polling/UnleashFetcher.kt
+++ b/src/main/kotlin/io/getunleash/polling/UnleashFetcher.kt
@@ -121,8 +121,8 @@ open class UnleashFetcher(
     }
 
     override fun close() {
-        this.httpClient.dispatcher.executorService.shutdownNow()
-        this.httpClient.connectionPool.evictAll()
-        this.httpClient.cache?.closeQuietly()
+        httpClient.dispatcher.executorService.shutdownNow()
+        httpClient.connectionPool.evictAll()
+        httpClient.cache?.closeQuietly()
     }
 }

--- a/src/test/kotlin/io/getunleash/metrics/HttpMetricsReporterTest.kt
+++ b/src/test/kotlin/io/getunleash/metrics/HttpMetricsReporterTest.kt
@@ -2,16 +2,19 @@ package io.getunleash.metrics
 
 import io.getunleash.UnleashConfig
 import io.getunleash.data.Variant
+import okhttp3.OkHttpClient
 import okhttp3.mockwebserver.MockResponse
 import okhttp3.mockwebserver.MockWebServer
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
+import java.util.concurrent.TimeUnit
 
 class HttpMetricsReporterTest {
 
     @Test
     fun metricsUrlIsCorrect() {
-        HttpMetricsReporter(UnleashConfig.newBuilder().proxyUrl("http://localhost:4242/proxy").clientKey("some-key").build()).use { reporter ->
+        val okHttpClient = OkHttpClient.Builder().build()
+        HttpMetricsReporter(UnleashConfig.newBuilder().proxyUrl("http://localhost:4242/proxy").clientKey("some-key").build(), okHttpClient).use { reporter ->
             assertThat(reporter.metricsUrl.toString()).isEqualTo("http://localhost:4242/proxy/client/metrics")
         }
     }

--- a/src/test/kotlin/io/getunleash/metrics/MetricsTest.kt
+++ b/src/test/kotlin/io/getunleash/metrics/MetricsTest.kt
@@ -7,6 +7,7 @@ import io.getunleash.UnleashContext
 import io.getunleash.data.Parser
 import io.getunleash.data.Variant
 import io.getunleash.polling.PollingModes
+import okhttp3.OkHttpClient
 import okhttp3.mockwebserver.MockResponse
 import okhttp3.mockwebserver.MockWebServer
 import org.assertj.core.api.Assertions.assertThat
@@ -18,6 +19,7 @@ import java.time.ZoneOffset
 import java.time.ZonedDateTime
 import java.util.Date
 import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.TimeUnit
 
 fun <K, V> concurrentHashMapOf(vararg pairs: Pair<K, V>): ConcurrentHashMap<K, V> {
     val map: ConcurrentHashMap<K, V> = ConcurrentHashMap()
@@ -158,7 +160,8 @@ class MetricsTest {
 
     @Test
     fun `http reporter does actually report toggles to metrics endpoint`() {
-        val reporter = HttpMetricsReporter(config)
+        val okHttpClient = OkHttpClient.Builder().build()
+        val reporter = HttpMetricsReporter(config, okHttpClient)
         val client = UnleashClient(config, context, metricsReporter = reporter)
         repeat(100) {
             client.isEnabled("unleash-android-proxy-sdk")


### PR DESCRIPTION
<!-- Thanks for creating a PR! To make it easier for reviewers and everyone else to understand what your changes relate to, please add some relevant content to the headings below. Feel free to ignore or delete sections that you don't think are relevant. Thank you! ❤️ -->

## About the changes
<!-- Describe the changes introduced. What are they and why are they being introduced? Feel free to also add screenshots or steps to view the changes if they're visual. -->
We have a way to set custom `OkHttpClient` for `UnleashClient`, however we are missing it for `HttpMetricsReporter`. Custom `OkHttpClient` is usefull when we want to add our own `Interceptor` (e.g. `HttpLoggingInterceptor`).

<!-- (For internal contributors): Does it relate to an issue on public roadmap? -->
<!--
Relates to [roadmap](https://github.com/orgs/Unleash/projects/10) item: #
-->
