### PR TITLE
Add the ability to remove toggle listeners that you have added

### DIFF
--- a/src/main/kotlin/io/getunleash/UnleashClient.kt
+++ b/src/main/kotlin/io/getunleash/UnleashClient.kt
@@ -156,11 +156,29 @@ class UnleashClient(
     }
 
     /**
+     * Removes a TogglesUpdatedListener from our [io.getunleash.polling.RefreshPolicy]
+     * @param listener the listener to remove
+     * @since 0.2
+     */
+    override fun removeTogglesUpdatedListener(listener: TogglesUpdatedListener) {
+        refreshPolicy.removeTogglesUpdatedListener(listener)
+    }
+
+    /**
      * Adds a TogglesErroredListener to our [io.getunleash.polling.RefreshPolicy]
      * @param listener the listener to add
      * @since 0.2
      */
     override fun addTogglesErroredListener(listener: TogglesErroredListener) {
         refreshPolicy.addTogglesErroredListener(listener)
+    }
+
+    /**
+     * Removes a TogglesErroredListener from our [io.getunleash.polling.RefreshPolicy]
+     * @param listener The listener to remove
+     * @since 0.2
+     */
+    override fun removeTogglesErroredListener(listener: TogglesErroredListener) {
+        refreshPolicy.removeTogglesErroredListener(listener)
     }
 }

--- a/src/main/kotlin/io/getunleash/UnleashClientSpec.kt
+++ b/src/main/kotlin/io/getunleash/UnleashClientSpec.kt
@@ -12,7 +12,9 @@ interface UnleashClientSpec : Closeable {
     fun updateContext(context: UnleashContext): CompletableFuture<Void>
     fun getContext(): UnleashContext
     fun addTogglesUpdatedListener(listener: TogglesUpdatedListener)
+    fun removeTogglesUpdatedListener(listener: TogglesUpdatedListener)
     fun addTogglesErroredListener(listener: TogglesErroredListener)
+    fun removeTogglesErroredListener(listener: TogglesErroredListener)
 
     fun startPolling()
     fun isPolling(): Boolean

--- a/src/main/kotlin/io/getunleash/polling/RefreshPolicy.kt
+++ b/src/main/kotlin/io/getunleash/polling/RefreshPolicy.kt
@@ -135,7 +135,7 @@ abstract class RefreshPolicy(
     }
 
     fun addTogglesUpdatedListener(listener: TogglesUpdatedListener): Unit {
-        synchronized(listener) {
+        synchronized(listeners) {
             listeners.add(listener)
         }
     }

--- a/src/main/kotlin/io/getunleash/polling/RefreshPolicy.kt
+++ b/src/main/kotlin/io/getunleash/polling/RefreshPolicy.kt
@@ -140,9 +140,21 @@ abstract class RefreshPolicy(
         }
     }
 
+    fun removeTogglesUpdatedListener(listener: TogglesUpdatedListener) {
+        synchronized(listeners) {
+            listeners.remove(listener)
+        }
+    }
+
     fun addTogglesErroredListener(errorListener: TogglesErroredListener): Unit {
         synchronized(errorListeners) {
             errorListeners.add(errorListener)
+        }
+    }
+
+    fun removeTogglesErroredListener(listener: TogglesErroredListener): Unit {
+        synchronized(errorListeners) {
+            errorListeners.remove(listener)
         }
     }
 

--- a/src/test/kotlin/io/getunleash/polling/RefreshPolicyTest.kt
+++ b/src/test/kotlin/io/getunleash/polling/RefreshPolicyTest.kt
@@ -1,7 +1,14 @@
 package io.getunleash.polling
 
+import io.getunleash.UnleashConfig
+import io.getunleash.UnleashContext
+import io.getunleash.data.Toggle
+import java9.util.concurrent.CompletableFuture
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
+import org.mockito.kotlin.mock
+import java.util.concurrent.atomic.AtomicBoolean
+import java.util.concurrent.atomic.LongAdder
 
 
 class RefreshPolicyTest {
@@ -10,5 +17,32 @@ class RefreshPolicyTest {
     fun `can sha256 a string`() {
         val s = RefreshPolicy.sha256("expected")
         assertThat(s).isEqualTo("cea23dd4b87e8b00d19fb9ccaaef93e97353c7353e2070f3baf05aeb3995dff4")
+    }
+
+    @Test
+    fun `Can add and remove an update listener`() {
+        val refreshPolicy = object : RefreshPolicy(
+            unleashFetcher = mock(),
+            cache = mock(),
+            logger = mock(),
+            config = UnleashConfig("", ""),
+            context = UnleashContext(),
+        ) {
+            override val isReady: AtomicBoolean = AtomicBoolean(true)
+
+            override fun getConfigurationAsync(): CompletableFuture<Map<String, Toggle>> {
+                error("Not applicable")
+            }
+
+            override fun startPolling() {}
+            override fun isPolling(): Boolean = false
+        }
+        val checks = LongAdder()
+        val togglesUpdatedListener = TogglesUpdatedListener { checks.add(1) }
+        refreshPolicy.addTogglesUpdatedListener(togglesUpdatedListener)
+        refreshPolicy.broadcastTogglesUpdated()
+        refreshPolicy.removeTogglesUpdatedListener(togglesUpdatedListener)
+        refreshPolicy.broadcastTogglesUpdated()
+        assertThat(checks.sum()).isEqualTo(1)
     }
 }


### PR DESCRIPTION
## About the changes
This adds two new public functions to RefreshPolicy, and by extension to UnleashClientSpec so that the caller can call them.

<!-- Does it close an issue? Multiple? -->
Closes #68

## Discussion points
I have not added remove functions for the other listeners, as they do not currently expose a function to add listeners through the `UnleashClientSpec`.
I have added a test to `RefreshPolicyTest` itself to ensure that adding and removing the listener works as expected.

The first commit fixes a little bug I think was there regarding what object was used for synchronization, which I think was simply a misspell. If that was not the case feel free to either revert that yourself or let me know so I can do it.