### PR TITLE
feat: metrics are now enabled by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,19 +173,7 @@ val client = UnleashClient(unleashConfig = config, unleashContext = context)
 ```
 
 ### Metrics (since v0.2)
-If you'd like the client to post metrics to the proxy so the admin interface can be updated, add a call to `enableMetrics()`.
-
-#### NB Only supported by SDK version >=26
-
-```kotlin
-val config = UnleashConfig
-    .newBuilder()
-    .appName()
-    .userId()
-    .sessionId()
-    .enableMetrics()
-    .build()
-```
+Metrics are automatically posted to the upstream, so the admin interface can be updated. To disable automatic metrics posting, call `disableMetrics()` on the builder.
 
 The default configuration configures a daemon to report metrics once every minute, this can be altered using the `metricsInterval(long milliseconds)` method on the builder, so if you'd rather see us post in 5 minutes intervals you could do
 ```kotlin

--- a/src/main/kotlin/io/getunleash/UnleashConfig.kt
+++ b/src/main/kotlin/io/getunleash/UnleashConfig.kt
@@ -50,7 +50,6 @@ data class UnleashConfig(
             httpClientConnectionTimeout = httpClientConnectionTimeout,
             httpClientReadTimeout = httpClientReadTimeout,
             httpClientCacheSize = httpClientCacheSize,
-            enableMetrics = reportMetrics != null,
             metricsInterval = reportMetrics?.metricsInterval
         )
 
@@ -73,7 +72,7 @@ data class UnleashConfig(
         var httpClientConnectionTimeout: Long? = null,
         var httpClientReadTimeout: Long? = null,
         var httpClientCacheSize: Long? = null,
-        var enableMetrics: Boolean = false,
+        var enableMetrics: Boolean = true,
         var metricsHttpClient: OkHttpClient? = null,
         var metricsInterval: Long? = null,
         var instanceId: String? = null,

--- a/src/test/kotlin/io/getunleash/UnleashConfigTest.kt
+++ b/src/test/kotlin/io/getunleash/UnleashConfigTest.kt
@@ -85,7 +85,7 @@ class UnleashConfigTest {
     }
 
     @Test
-    fun `Can enable metrics with builder method`() {
+    fun `Can disable metrics with builder method`() {
         val config = UnleashConfig(
             proxyUrl = "https://localhost:4242/proxy",
             clientKey = "some-key",
@@ -93,8 +93,8 @@ class UnleashConfigTest {
             environment = "default"
         )
         assertThat(config.reportMetrics).isNull()
-        val withMetrics = config.newBuilder().enableMetrics().build()
-        assertThat(withMetrics.reportMetrics).isNotNull
+        val withMetrics = config.newBuilder().disableMetrics().build()
+        assertThat(withMetrics.reportMetrics).isNull()
     }
 
     @Test
@@ -106,8 +106,8 @@ class UnleashConfigTest {
             environment = "default"
         )
 
-        val configInMs = config.newBuilder().enableMetrics().metricsInterval(5000).build()
-        val configWithMetricsSetInSeconds = config.newBuilder().enableMetrics().metricsIntervalInSeconds(5).build()
+        val configInMs = config.newBuilder().metricsInterval(5000).build()
+        val configWithMetricsSetInSeconds = config.newBuilder().metricsIntervalInSeconds(5).build()
         assertThat(configInMs.reportMetrics!!.metricsInterval).isEqualTo(configWithMetricsSetInSeconds.reportMetrics!!.metricsInterval)
     }
 
@@ -120,7 +120,7 @@ class UnleashConfigTest {
             environment = "default"
         )
         assertThat(config.reportMetrics).isNull()
-        val withMetrics = config.newBuilder().enableMetrics().build()
+        val withMetrics = config.newBuilder().build()
         assertThat(withMetrics.reportMetrics).isNotNull
         assertThat(withMetrics.reportMetrics!!.httpClient.connectTimeoutMillis).isEqualTo(config.httpClientConnectionTimeout)
         assertThat(withMetrics.reportMetrics!!.httpClient.readTimeoutMillis).isEqualTo(config.httpClientReadTimeout)
@@ -136,7 +136,7 @@ class UnleashConfigTest {
         )
         assertThat(config.reportMetrics).isNull()
         val okHttpClient = OkHttpClient.Builder().build()
-        val withMetrics = config.newBuilder().enableMetrics().metricsHttpClient(okHttpClient).build()
+        val withMetrics = config.newBuilder().metricsHttpClient(okHttpClient).build()
         assertThat(withMetrics.reportMetrics).isNotNull
         assertEquals(okHttpClient, withMetrics.reportMetrics!!.httpClient)
     }


### PR DESCRIPTION
Based on https://github.com/Unleash/unleash-android-proxy-sdk/issues/74, we are now enabling posting metrics by default. This makes it consistant with other Unleash SDKs.