### PR TITLE
docs: Update README to reflect how appName can be used for metrics

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,6 @@ build
 *.ipr
 *.iws
 bin/
+
+# Ignore local gradle properties
+local.properties

--- a/README.md
+++ b/README.md
@@ -50,7 +50,6 @@ You should use a singleton pattern to avoid file contention on cache directory.
 #### Step 3a: Unleash Context
 
 The important properties to configure on the context are
-* Appname - In case you use strategies that depend on which app
 * UserId - GradualRolloutStrategies often use this to decide stickiness when assigning which group of users the user end up in
 * SessionId - GradualRolloutStrategies often use this to decide stickiness
 
@@ -58,7 +57,6 @@ The important properties to configure on the context are
 import io.getunleash.UnleashContext
 
 val context = UnleashContext.newBuilder()
-    .appName("Your AppName")
     .userId("However you resolve your userid")
     .sessionId("However you resolve your session id") 
     .build()
@@ -67,6 +65,7 @@ val context = UnleashContext.newBuilder()
 #### Step 3b: Unleash Config
 To create a client, use the UnleashConfig.newBuilder method. When building a configuration, you'll need to provide it with:
 
+- `appName`: the name of the application to be used in strategies and metrics
 - `proxyUrl`: the URL the Unleash front-end API is available at **OR** the URL your proxy is available at
 - `clientKey`: the API token or proxy client key you wish to use (this method was known as clientSecret prior to version 0.4.0)
 - `pollMode`: how you want to load the toggle status
@@ -87,6 +86,7 @@ Configuring a client with a 60 seconds poll interval:
 
 ```kotlin
 val config = UnleashConfig.newBuilder()
+    .appName("Your AppName")
     .proxyUrl("URL to your front-end API or proxy")
     .clientKey("your front-end API token or proxy client key")
     .pollingMode(PollingModes.autoPoll(60) { // poll interval in seconds
@@ -107,6 +107,7 @@ val toggles = File("/tmp/proxyresponse.json")
 val pollingMode = PollingModes.fileMode(toggles)
 
 val config = UnleashConfig.newBuilder()
+    .appName("Your AppName")
     .proxyUrl("Doesn't matter since we don't use it when sent a file")
     .clientKey("Doesn't matter since we don't use it when sent a file")
     .pollMode(pollingMode)
@@ -136,11 +137,11 @@ The listener is a no-argument lambda that gets called by the RefreshPolicy for e
 Example usage is equal to the `Example setup` above
 ```kotlin
 val context = UnleashContext.newBuilder()
-    .appName("Your AppName")
     .userId("However you resolve your userid")
     .sessionId("However you resolve your session id")
     .build()
 val config = UnleashConfig.newBuilder()
+    .appName("Your AppName")
     .proxyUrl("URL to your front-end API or proxy")
     .clientKey("your front-end API token or proxy client key")
     .pollingMode(PollingModes.autoPoll(60) { // poll interval in seconds
@@ -159,11 +160,11 @@ The following example shows how to use it, provided the file to use is located a
 val toggles = File("/tmp/proxyresponse.json")
 val pollingMode = PollingModes.fileMode(toggles)
 val context = UnleashContext.newBuilder()
-    .appName("Your AppName")
     .userId("However you resolve your userid")
     .sessionId("However you resolve your session id")
     .build()
 val config = UnleashConfig.newBuilder()
+    .appName("Your AppName")
     .proxyUrl("URL to your front-end API or proxy") // These two don't matter for FilePolling,
     .clientKey("front-end API token / proxy client key") // since the client never speaks to the proxy
     .pollingMode(pollingMode)

--- a/src/main/kotlin/io/getunleash/UnleashConfig.kt
+++ b/src/main/kotlin/io/getunleash/UnleashConfig.kt
@@ -15,7 +15,7 @@ data class ReportMetrics(
  * Represents configuration for Unleash.
  * @property proxyUrl HTTP(s) URL to the Unleash Proxy (Required).
  * @property clientKey the key added as the Authorization header sent to the unleash-proxy (Required)
- * @property appName: name of the underlying application. Will be used as default in the [io.getunleash.UnleashContext] call (Required).
+ * @property appName: name of the underlying application. Will be used as default in the [io.getunleash.UnleashContext] call (Optional - Defaults to 'unknown').
  * @property environment which environment is the application running in. Will be used as default argument for the [io.getunleash.UnleashContext]. (Optional - Defaults to 'default')
  * @property instanceId instance id of your client
  * @property pollingMode How to poll for features. Defaults to [io.getunleash.polling.AutoPollingMode] with poll interval set to 60 seconds.

--- a/src/main/kotlin/io/getunleash/UnleashContext.kt
+++ b/src/main/kotlin/io/getunleash/UnleashContext.kt
@@ -13,10 +13,8 @@ package io.getunleash
  * @property remoteAddress the Ip address of the client. If your feature uses the remoteAddress strategy
  * you'll need to set this
  * @property properties - Other properties for custom strategies.
- * @property appName - The name of your app - mostly used for metrics server side, but someone might use this to
- * evaluate a strategy as well
- * @property environment - Which environment are you running in? Not currently supported server side
- * (per Unleash-server v4.0.0), but support is coming, and can be used for custom strategies
+ * @property appName - The name of your app, used for evaluating strategies - defaults to the one set in the [io.getunleash.UnleashConfig]
+ * @property environment - Which environment are you running in - defaults to the one set in the [io.getunleash.UnleashConfig]
  */
 data class UnleashContext(
     val userId: String? = null,


### PR DESCRIPTION
## About the changes
If following the current version of the documentation, you will just see `unknown` as the appName in the unleash console.  Now that metrics are enabled by default, more people will be seeing this.

## Discussion points
Since `UnleashContext` gets the appName from `UnleashConfig` (if it is not set in both places) I really think it should be removed from `UnleashContext` completely.  But it felt like an overstep to make a design decision in a PR like this 😅. I think having the ability to have two different "app names" is weird behavior though.

But at least the documentation should reflect a better way to set a single app name for your app that will be visible in all places. I had to dive into the source code to figure out why we were appearing as `unknown` in metrics, since the documentation (both readme and the kdoc) implied that the `appName` from `UnleashContext` would be used for metrics.
